### PR TITLE
[WIP] S3へのアップロードを制限する

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -37,6 +37,9 @@ class ImageUploader < CarrierWave::Uploader::Base
     %w(jpg jpeg png)
   end
 
+  def size_range
+    1..5.megabytes
+  end
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.
   # def filename

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -33,9 +33,9 @@ class ImageUploader < CarrierWave::Uploader::Base
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  # def extension_whitelist
-  #   %w(jpg jpeg gif png)
-  # end
+  def extension_whitelist
+    %w(jpg jpeg png)
+  end
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.


### PR DESCRIPTION
# What
S3へアップロードできるものを制限する
# Why
現在S3にすべてのものをアップロードすることができる。
そのため悪意あるユーザーが存在した場合、S3へ莫大なサイズのファイルをアップロードされることが想定される。その対策を行うため。